### PR TITLE
Add top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# claude-code-in-one-shot
+
+Projects built end-to-end with [Claude Code](https://claude.ai/code) in a single session — scaffolded, dockerized, deployed, and documented from one prompt-driven flow.
+
+## Projects
+
+| Project | Stack | Status |
+|---|---|---|
+| [`projects/portfolio/`](projects/portfolio/) | Astro static site + nginx + ngrok, GitHub-driven | Phase 1 complete |
+
+Additional one-shot projects (backend, URL shortener, pastebin, CLI todo, Temporal demo, Claude API chatbot) are tracked in [issue #1](https://github.com/LondheShubham153/claude-code-in-one-shot/issues/1).
+
+## Repo conventions
+
+Each project under `projects/<name>/` follows the same shape:
+
+- `README.md` — what it is, how to run it locally
+- `tasks.md` — source of truth for task state
+- `decisions/` — numbered ADRs (`0001-*.md`, `0002-*.md`, …)
+
+The root [`CLAUDE.md`](CLAUDE.md) routes Claude Code into the active project and lists common commands.
+
+## Quickstart (portfolio)
+
+Requires Node ≥20, Docker, and an `NGROK_AUTHTOKEN` for the public tunnel.
+
+```bash
+cd projects/portfolio
+npm install
+npm run build              # produces dist/
+docker compose up --build  # nginx-served site + ngrok sidecar
+```
+
+See [`projects/portfolio/README.md`](projects/portfolio/README.md) for the full setup, environment variables, and architecture notes.
+
+## `.claude/` setup
+
+Each project ships its own `.claude/` directory with:
+
+- a `code-reviewer` subagent that runs on file changes
+- `PostToolUse` / `FileChanged` hooks wired in `.claude/settings.local.json`
+
+This pattern is reusable across projects — copy the directory into a new project and adjust the agent prompts.
+
+## Contributing
+
+Fork, swap in your own GitHub username (used by the portfolio's GitHub-driven content), and follow the project's README. See issue #1 for the documentation backlog and proposed projects.


### PR DESCRIPTION
Addresses the **Top-level `README.md`** checkbox in #1.

## Summary

- Adds a root `README.md` that explains what this repo is, lists the active project (`projects/portfolio/`), points at the documentation backlog in #1, and gives a quickstart for the portfolio.
- Documents the per-project convention (`README.md` / `tasks.md` / `decisions/`) and the reusable `.claude/` setup so the pattern is discoverable to anyone forking the repo.

Synthesized from `CLAUDE.md` and the issue body — no code changes.

## Checklist (from #1)

- [x] Top-level `README.md`
- [ ] Quickstart per project — already present in `projects/portfolio/README.md`; future projects should match
- [ ] Architecture / decisions index — partial (links into the project's `decisions/`); a fuller ADR index can land separately
- [ ] `.claude/` walkthrough — short blurb included; deeper write-up can be its own PR
- [ ] Contributing — short note included
- [ ] Repo-level `LICENSE` — separate PR
- [ ] Cleanup of `demo/` and `demo-1.txt` — separate PR

## Test plan

- [ ] Render `README.md` on GitHub and verify all relative links resolve
- [ ] Confirm the quickstart commands match what's in `projects/portfolio/`
- [ ] Confirm tone and project list match what you want to advertise

🤖 Opened by a Claude Code agent (manual trigger run). Refs #1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive repository landing page with project status and workflow documentation.
  * Included quickstart guide for setup and development environment configuration.
  * Documented standardized project structure and contributing guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->