### PR TITLE
Add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shubham Londhe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Addresses the **Repo-level `LICENSE`** checkbox in #1.

## Summary

- Adds an MIT `LICENSE` at the repo root, copyright "2026 Shubham Londhe".
- MIT is the default for showcase / one-shot project repos; swap for Apache-2.0, BSD-3-Clause, or another license in review if you'd prefer something else.

## Checklist (from #1)

- [x] Repo-level `LICENSE`

## Test plan

- [ ] Confirm MIT is the license you want (vs. Apache-2.0 / BSD-3-Clause / proprietary)
- [ ] Confirm the copyright holder name ("Shubham Londhe") is how you want to be credited
- [ ] After merge, GitHub's repo sidebar should pick up the license automatically

🤖 Opened by a Claude Code agent (manual trigger run). Refs #1.
